### PR TITLE
fix composite.merge for indices

### DIFF
--- a/packages/devtools/src/composite.ts
+++ b/packages/devtools/src/composite.ts
@@ -580,6 +580,7 @@ export class Composite {
       Object.assign(nextParams.commits, commits)
       Object.assign(nextDefinition.models, definition.models)
       Object.assign(nextDefinition.aliases, def.aliases)
+      Object.assign(nextDefinition.indices, def.indices)
       merge(nextDefinition.views, def.views)
       for (const name of def.commonEmbeds) {
         collectedEmbeds.add(name)


### PR DESCRIPTION


# [Replace Me With Meaningful Name] - #[Issue]

## Description

The merge method from Composite class discards all the additional indices from the merged sources. This patch fixes it by ensuring that the indices are being passed to the nextDefinition

## How Has This Been Tested?

I've used this package versions with my local inmemory configuration
```
    "@ceramicnetwork/cli": "2.36.0-rc.2",
    "@ceramicnetwork/common": "2.31.0-rc.1",
    "@ceramicnetwork/http-client": "2.28.0-rc.1",
    "@composedb/cli": "0.5.0-rc.2",
    "@composedb/client": "0.5.0-rc.2",
    "@composedb/devtools": "0.5.0-rc.2",
    "@composedb/devtools-node": "0.5.0-rc.2"
```

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

